### PR TITLE
maint: Refactor to use pymodbus v.3.11.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "unipi-one-modbus"
-version = "0.24"
+version = "0.25"
 authors = [
   { name="Miroslav Ondra", email="ondra@unipi.technology" },
 ]
@@ -18,7 +18,7 @@ classifiers = [
 ]
 
 dependencies = [
-    'pymodbus == 3.5.4',
+    'pymodbus == 3.11.4',
     'PyYAML == 6.0.1',
     'pylibiio == 0.25',
     'gpiod == 2.1.1'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pymodbus ~= 3.5.4
+pymodbus ~= 3.11.4
 PyYAML ~= 6.0.1
 pylibiio ~= 0.25
 gpiod ~= 2.1.1

--- a/unipi_one_modbus/modbus/server.py
+++ b/unipi_one_modbus/modbus/server.py
@@ -6,13 +6,11 @@ from .. import __version__ as unipi_one_version
 from pymodbus.datastore import (
     ModbusSequentialDataBlock,
     ModbusServerContext,
-    ModbusSlaveContext,
+    ModbusDeviceContext,
     ModbusSparseDataBlock,
 )
-from pymodbus.transaction import ModbusSocketFramer
-from pymodbus.device import ModbusDeviceIdentification
+from pymodbus.pdu.device import ModbusDeviceIdentification
 from pymodbus.server import ModbusTcpServer
-#from pymodbus.server import StartAsyncTcpServer
 
 from ..rpcmethods import DevMeta, get_kwargs
 
@@ -56,9 +54,9 @@ class ModbusServer(metaclass=DevMeta):
         logging.info(txt)
 
         identity = ModbusDeviceIdentification(info_name=self.info_name)
-        context  = ModbusServerContext(slaves=self.slaves, single=False)
+        context  = ModbusServerContext(devices=self.slaves, single=False)
 
-        self.server = ModbusTcpServer(context, ModbusSocketFramer, identity, address)
+        self.server = ModbusTcpServer(context, identity=identity, address=address)
         with suppress(asyncio.exceptions.CancelledError):
             try:
                 await self.server.serve_forever()


### PR DESCRIPTION
Using pymodbus 3.11.4 solves problem with missing async support in setting coils/registers.